### PR TITLE
ModelPredicateRegistry for all items (including other mods)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.8-SNAPSHOT'
+	id 'fabric-loom' version '0.9-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
 	minecraft_version=1.17.1
-	yarn_mappings=1.17.1+build.54
-	loader_version=0.11.6
+	yarn_mappings=1.17.1+build.61
+	loader_version=0.12.2
 
 # Mod Properties
 	mod_version = 1.2
@@ -13,4 +13,4 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = eating-animation
 
 # Dependencies
-	fabric_version=0.40.0+1.17
+	fabric_version=0.40.8+1.17

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.12.2
 
 # Mod Properties
-	mod_version = 1.2
+	mod_version = 1.3
 	maven_group = ru.tpsd.eatinganimationmod
 	archives_base_name = eating-animation
 

--- a/src/main/java/ru/tpsd/eatinganimationmod/EatingAnimationClientMod.java
+++ b/src/main/java/ru/tpsd/eatinganimationmod/EatingAnimationClientMod.java
@@ -11,42 +11,43 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 public class EatingAnimationClientMod implements ClientModInitializer {
-
-   public static float a = 0;
+    public static float a = 0;
+    @Deprecated(since = "1.3")
     public static final ArrayList<Item> VANILLA_FOOD = new ArrayList<>(Arrays.asList(
-            Items.APPLE, Items.BAKED_POTATO, Items.BEEF, Items.BEETROOT, Items.CARROT,
-            Items.CHICKEN, Items.BREAD, Items.CHORUS_FRUIT, Items.COD, Items.COOKED_BEEF,
-            Items.COOKED_CHICKEN, Items.COOKED_COD, Items.COOKED_MUTTON, Items.COOKED_PORKCHOP, Items.COOKED_RABBIT,
-            Items.COOKED_SALMON, Items.COOKIE, Items.DRIED_KELP, Items.GLOW_BERRIES, Items.GOLDEN_APPLE, Items.GOLDEN_CARROT,
-            Items.HONEY_BOTTLE, Items.MELON_SLICE, Items.MILK_BUCKET, Items.MUSHROOM_STEW, Items.MUTTON, Items.POISONOUS_POTATO,
-            Items.PORKCHOP, Items.POTATO, Items.PUMPKIN_PIE, Items.RABBIT, Items.RABBIT_STEW, Items.BEETROOT_SOUP,
-            Items.ROTTEN_FLESH, Items.SALMON, Items.SPIDER_EYE, Items.SUSPICIOUS_STEW, Items.SWEET_BERRIES, Items.TROPICAL_FISH,
-            Items.ENCHANTED_GOLDEN_APPLE
+        Items.APPLE, Items.BAKED_POTATO, Items.BEEF, Items.BEETROOT, Items.CARROT,
+        Items.CHICKEN, Items.BREAD, Items.CHORUS_FRUIT, Items.COD, Items.COOKED_BEEF,
+        Items.COOKED_CHICKEN, Items.COOKED_COD, Items.COOKED_MUTTON, Items.COOKED_PORKCHOP, Items.COOKED_RABBIT,
+        Items.COOKED_SALMON, Items.COOKIE, Items.DRIED_KELP, Items.GLOW_BERRIES, Items.GOLDEN_APPLE, Items.GOLDEN_CARROT,
+        Items.HONEY_BOTTLE, Items.MELON_SLICE, Items.MILK_BUCKET, Items.MUSHROOM_STEW, Items.MUTTON, Items.POISONOUS_POTATO,
+        Items.PORKCHOP, Items.POTATO, Items.PUMPKIN_PIE, Items.RABBIT, Items.RABBIT_STEW, Items.BEETROOT_SOUP,
+        Items.ROTTEN_FLESH, Items.SALMON, Items.SPIDER_EYE, Items.SUSPICIOUS_STEW, Items.SWEET_BERRIES, Items.TROPICAL_FISH,
+        Items.ENCHANTED_GOLDEN_APPLE
     ));
 
 
     @Override
     public void onInitializeClient() {
+        registerEatingPredicate();
+    }
 
-        for (Item item : VANILLA_FOOD) {
-            FabricModelPredicateProviderRegistry.register(item, new Identifier("eat"), (itemStack, clientWorld, livingEntity, i) -> {
-                if (livingEntity == null) {
-                    return 0.0F;
-                }
+    private void registerEatingPredicate() {
+        FabricModelPredicateProviderRegistry.register(new Identifier("eat"), (itemStack, clientWorld, livingEntity, i) -> {
+            if (livingEntity == null) {
+                return 0.0F;
+            }
 
-                if(livingEntity instanceof OtherClientPlayerEntity && livingEntity.getItemUseTime() > 31){
-return a / 30;
-                }
-                return livingEntity.getActiveItem() != itemStack ? 0.0F : (itemStack.getMaxUseTime() - livingEntity.getItemUseTimeLeft()) / 30.0F;
-            });
+            if(livingEntity instanceof OtherClientPlayerEntity && livingEntity.getItemUseTime() > 31){
+                return a / 30;
+            }
+            return livingEntity.getActiveItem() != itemStack ? 0.0F : (itemStack.getMaxUseTime() - livingEntity.getItemUseTimeLeft()) / 30.0F;
+        });
 
-            FabricModelPredicateProviderRegistry.register(item, new Identifier("eating"), (itemStack, clientWorld, livingEntity, i) -> {
-                if (livingEntity == null) {
-                    return 0.0F;
-                }
+        FabricModelPredicateProviderRegistry.register(new Identifier("eating"), (itemStack, clientWorld, livingEntity, i) -> {
+            if (livingEntity == null) {
+                return 0.0F;
+            }
 
-                return livingEntity.isUsingItem() && livingEntity.getActiveItem() == itemStack ? 1.0F : 0.0F;
-            });
-        }
+            return livingEntity.isUsingItem() && livingEntity.getActiveItem() == itemStack ? 1.0F : 0.0F;
+        });
     }
 }


### PR DESCRIPTION
As requested by issues such as #3. It is quite easy to do this. Instead of registering a `FabricModelPredicateProviderRegistry` for only vanilla food items,  one can instead do it for **all** items.

However, this doesn't mean that the game expects all items to have a "eating" in their model. It means that it _could_ have this.

I tested this with Farmers Delight and it worked. Added is a resource-pack that has the eating animations working for `apple_pie_slice `and `cooked_rice`.
File: [ExampleFarmersDelight.zip](https://github.com/Theoness1/EatingAnimation/files/7357873/ExampleFarmersDelight.zip).

_To add FarmersDelight [Fabric] to the dev environment you can use `modImplementation files(<mod>.jar)` in `build.gradle`_

If you want @Theoness1, you can add me to contributors in the file `fabric.mod.json`. However I changed only a little so I understand if you will not.